### PR TITLE
Updating gitignore to ignore generated executables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,10 @@
 /nbproject/
 /.idea/
 /bin/behat
+/bin/doctrine-dbal
+/bin/pscss
 /bin/phpunit
+/bin/security-checker
 /app/check.php
 /app/SymfonyRequirements.php
 /app/cache/


### PR DESCRIPTION
Some files are added to /bin that we should not track in git.