### PR TITLE
COM-19998: Blog Remove white area above the footer

### DIFF
--- a/app/Resources/views/full/blog.html.twig
+++ b/app/Resources/views/full/blog.html.twig
@@ -1,7 +1,7 @@
 {% extends 'pagelayout.html.twig' %}
 
 {% block content %}
-    <div class="blog">
+    <section class="blog">
         <div class="blog-top-banner">
             <div class="container">
                 Developer<span>Blog</span>
@@ -26,5 +26,5 @@
                 </div>
             </div>
         </div>
-    </div>
+    </section>
 {% endblock %}

--- a/app/Resources/views/full/blog_post.html.twig
+++ b/app/Resources/views/full/blog_post.html.twig
@@ -25,7 +25,7 @@
 {% endblock %}
 
 {% block content %}
-    <div class="blog-post">
+    <section class="blog-post">
         <div class="blog-post-header">
             <div class="container">
                 <h1>
@@ -66,5 +66,5 @@
                 </div>
             {% endif %}
         </div>
-    </div>
+    </section>
 {% endblock %}

--- a/app/Resources/views/full/bundle_list.html.twig
+++ b/app/Resources/views/full/bundle_list.html.twig
@@ -1,7 +1,7 @@
 {% extends 'pagelayout.html.twig' %}
 
 {% block content %}
-    <div class="bundles-list">
+    <section class="bundles-list">
         <div class="bundles-list-header">
             <div class="container">
                 <div class="row">
@@ -31,5 +31,5 @@
                 </div>
             </div>
         </div>
-    </div>
+    </section>
 {% endblock %}

--- a/web/assets/css/ezplatform-com.css
+++ b/web/assets/css/ezplatform-com.css
@@ -198,6 +198,10 @@ a.btn.btn-outline:visited {
     margin-top: 12px;
 }
 
+section {
+    padding: 0 0 50px 0;
+}
+
 footer .logo {
     margin-bottom: 20px;
     width: 120px;
@@ -206,7 +210,6 @@ footer .logo {
 .footer-content {
     color: #e6e7e8;
     background-color: #4c4c4c;
-    margin-top: 50px;
     padding-top: 50px;
     padding-bottom: 50px;
 }


### PR DESCRIPTION
JIRA issue: [https://jira.ez.no/browse/COM-19998](https://jira.ez.no/browse/COM-19998)

### Description
As described in issue, on all pages with the background different than `#fff` white area was visible above the footer. It was caused by `margin-top: 50px` in footer CSS.
After this change providing this space is done in CSS for `section`. Therefore we should place all of the content inside the `section` tag instead of `div`.
