### PR TITLE
COM-19996: The image variation of the listing image is too heavy

### DIFF
--- a/app/config/config_ezplatform_page.yml
+++ b/app/config/config_ezplatform_page.yml
@@ -26,6 +26,11 @@ parameters:
     # names of excluded bundle maintainers
     bundles.excluded_maintainers: ['ezrobot']
 
+    # default png compression level used in image_variations.yml
+    images.default_png_compression_level: 9
+    # default jpeg quality used in image_variations.xml
+    images.default_jpeg_quality: 90
+
 # additional PlatformUI configuration
 ez_platformui:
     system:

--- a/app/config/image_variations.yml
+++ b/app/config/image_variations.yml
@@ -21,8 +21,17 @@ ezpublish:
                     filters:
                         - { name: geometry/scalewidthdownonly, params: [710] }
 liip_imagine:
-    driver: imagick
+    driver: imagic
     filter_sets:
         blog_thumbnail:
-            png_compression_level: 9
-            jpeg_quality: 90
+            png_compression_level: '%images.default_png_compression_level%'
+            jpeg_quality: '%images.default_jpeg_quality%'
+        blog_author:
+            png_compression_level: '%images.default_png_compression_level%'
+            jpeg_quality: '%images.default_jpeg_quality%'
+        blog_post_author:
+            png_compression_level: '%images.default_png_compression_level%'
+            jpeg_quality: '%images.default_jpeg_quality%'
+        blog_thumbnail:
+            png_compression_level: '%images.default_png_compression_level%'
+            jpeg_quality: '%images.default_jpeg_quality%'

--- a/app/config/image_variations.yml
+++ b/app/config/image_variations.yml
@@ -25,3 +25,4 @@ liip_imagine:
     filter_sets:
         blog_thumbnail:
             png_compression_level: 9
+            jpeg_quality: 90

--- a/app/config/image_variations.yml
+++ b/app/config/image_variations.yml
@@ -23,15 +23,12 @@ ezpublish:
 liip_imagine:
     driver: imagic
     filter_sets:
-        blog_thumbnail:
+        blog_thumbnail: &default
             png_compression_level: '%images.default_png_compression_level%'
             jpeg_quality: '%images.default_jpeg_quality%'
         blog_author:
-            png_compression_level: '%images.default_png_compression_level%'
-            jpeg_quality: '%images.default_jpeg_quality%'
+            *default
         blog_post_author:
-            png_compression_level: '%images.default_png_compression_level%'
-            jpeg_quality: '%images.default_jpeg_quality%'
+            *default
         blog_thumbnail:
-            png_compression_level: '%images.default_png_compression_level%'
-            jpeg_quality: '%images.default_jpeg_quality%'
+            *default

--- a/app/config/image_variations.yml
+++ b/app/config/image_variations.yml
@@ -20,3 +20,8 @@ ezpublish:
                     reference: ~
                     filters:
                         - { name: geometry/scalewidthdownonly, params: [710] }
+liip_imagine:
+    driver: gd
+    filter_sets:
+        blog_thumbnail:
+            png_compression_level: 9

--- a/app/config/image_variations.yml
+++ b/app/config/image_variations.yml
@@ -21,7 +21,7 @@ ezpublish:
                     filters:
                         - { name: geometry/scalewidthdownonly, params: [710] }
 liip_imagine:
-    driver: gd
+    driver: imagick
     filter_sets:
         blog_thumbnail:
             png_compression_level: 9


### PR DESCRIPTION
**JIRA issue:** [https://jira.ez.no/browse/COM-19996](https://jira.ez.no/browse/COM-19996)

### Description
As described in issue, image thumbnails created by **liipimagine** was very heavy. 
Compression level for **PNG** files was set to 9 and I have not noticed any visible quality loss.
Also, quality of **JPEG** files was set to 90% and images still look good.

The solution provided according to: 
[https://doc.ez.no/display/DEVELOPER/Images#Images-Imagequalitywithaliipfilter](https://doc.ez.no/display/DEVELOPER/Images#Images-Imagequalitywithaliipfilter)

| File name  | File size before | File size after |
| ---------- | ----------- | ---------- |
| ezplatform-1.9.png  | ~992KB  | ~45.4KB |
| question-mark-1495858_960_720.jpg  | ~127KB  | ~48.8KB |