### PR TITLE
COM-19997: [Blog] - Embed images are not responsive

### DIFF
--- a/web/assets/css/blog_post.css
+++ b/web/assets/css/blog_post.css
@@ -64,6 +64,10 @@
     margin: 0 0 30px;
 }
 
+.blog-post-body figure.ezimage-field img {
+    max-width: 100%;
+}
+
 .blog-post-comments {
     margin-top: 25px;
 }


### PR DESCRIPTION
**JIRA issue:** [https://jira.ez.no/browse/COM-19997](https://jira.ez.no/browse/COM-19997)

### Description
As described in issue, embed images are not responsive. 
Bug fixed by adding `max-width: 100%` on `img` inside `figure.ezimage-field`.
