### PR TITLE
COM-20003: Homepage no view template Twig exception

### DIFF
--- a/app/config/views.yml
+++ b/app/config/views.yml
@@ -21,6 +21,7 @@ ezpublish:
                                     excluded_content_types:
                                         - layout
                                         - article
+                                        - bundle_list
                                 assign_results_to: items
                         template: full\home.html.twig
                         match:


### PR DESCRIPTION
**JIRA issue**: [https://jira.ez.no/browse/COM-20003](https://jira.ez.no/browse/COM-20003)

### Description

As described in issue, Twig exception was thrown because there is no view configuration for **row** content view. To fix it Bundle List ContentType was added to **excluded_content_types** parameter in query configuration. 
