### PR TITLE
COM-19941: [Blog Post] - Image caption is not displayed

### DIFF
--- a/app/Resources/views/embed/image.html.twig
+++ b/app/Resources/views/embed/image.html.twig
@@ -6,6 +6,6 @@
     }) }}
 
     <div class="embed-image-caption">
-        {{ ez_render_field(content, 'name') }}
+        {{ ez_render_field(content, 'caption') }}
     </div>
 </div>

--- a/web/assets/css/embed.css
+++ b/web/assets/css/embed.css
@@ -37,14 +37,19 @@
 
 .embed-image {
     margin: 0 0 30px 0;
-    background: #4c4c4c;
     display: inline-block;
     padding: 0;
 }
 
 .embed-image .embed-image-caption {
     margin-top: 5px;
-    font-size: 12px;
-    color: #ccc;
-    padding: 10px;
+    font-size: 13px;
+    color: #666;
+    padding: 10px 0;
+    font-style: italic;
+}
+
+.embed-image .embed-image-caption p {
+    font-size: 13px;
+    margin: 0;
 }


### PR DESCRIPTION
**JIRA issue**: [https://jira.ez.no/browse/COM-19941](https://jira.ez.no/browse/COM-19941) 

### Description
Image caption changed as proposed in issue. 

> what if there is some formatting in the caption field?

Yes, there is default formatting. This field is RichText so is rendered as paragraphs inside `.ezrichtext-field`. To display caption properly additional CSS was added: https://github.com/kmadejski/ezplatform-com/blob/COM-19941_Image_caption_is_not_displayed/web/assets/css/embed.css#L52-L55


