### PR TITLE
COM-20009: Exception while rendering blog post with Embed Code

### DIFF
--- a/app/Resources/views/embed/code.html.twig
+++ b/app/Resources/views/embed/code.html.twig
@@ -2,10 +2,9 @@
     {% set languageOptions = ez_field_options('code', 'language') %}
     {% set language = 'none' %}
     {% set embedLanguage = ez_field_value(content, 'language') %}
-    {% if languageOptions[embedLanguage] is defined %}
-        {% set language = languageOptions[embedLanguage] %}
+    {% if embedLanguage.selection is not empty and languageOptions[embedLanguage.selection[0]] is defined %}
+        {% set language = languageOptions[embedLanguage.selection[0]] %}
     {% endif %}
-
     {% spaceless %}
         <div class="embed-code">
             <pre>


### PR DESCRIPTION
**JIRA issue**: [https://jira.ez.no/browse/COM-20009](https://jira.ez.no/browse/COM-20009)

### Description
An Exception or Warning was caused by incorrect usage of `embedLanguage` which is an instance of `Value` and contains `selection` array. 

