### PR TITLE
COM-20017: Improve install process

### DIFF
--- a/dump_storage.sh
+++ b/dump_storage.sh
@@ -41,7 +41,7 @@ mkdir ${TMP_WORKING_DIR}/${PACKAGES_PATH}
 
 cd ${SOURCE_PATH}/${PACKAGES_PATH}
 echo "Creating text file."
-echo "Please download archive from http://ezplatform.com" > README.txt
+echo "Please download archive from http://ezplatform.com" > ${README_FILE}
 
 echo "Creating archives."
 for archive in ${ARCHIVE_EXTENSIONS}

--- a/dump_storage.sh
+++ b/dump_storage.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+if [ $# -ne 2 ]
+    then
+        echo "Incorrect number of arguments passed."
+        exit
+fi
+
+if [ -z "$1" ]
+    then
+        echo "Incorrect value of first argument passed."
+        exit
+fi
+
+if [ -z "$2" ]
+    then
+        echo "Incorrect value of second argument passed."
+        exit
+fi
+
+
+TMP_WORKING_DIR=$1
+DIRECTORY_PATH=$2
+
+ARCHIVE_EXTENSIONS="*.bz2 *.gz"
+BACKUP_DIRECTORY="backup"
+README_FILE="README.txt"
+
+ARCHIVE_PATH=${DIRECTORY_PATH}/web/dumps/ezplatform_page_storage.tar.bz2
+SOURCE_PATH=${DIRECTORY_PATH}/web/var/site/storage/
+
+PACKAGES_PATH="original/application"
+ALIASES_PATH="images/_aliases"
+
+mkdir ${TMP_WORKING_DIR}
+
+echo "Copying files."
+rsync -a ${SOURCE_PATH} ${TMP_WORKING_DIR} --exclude=${ALIASES_PATH} --exclude=${PACKAGES_PATH}
+
+mkdir ${TMP_WORKING_DIR}/${PACKAGES_PATH}
+
+cd ${SOURCE_PATH}/${PACKAGES_PATH}
+echo "Creating text file."
+echo "Please download archive from http://ezplatform.com" > README.txt
+
+echo "Creating archives."
+for archive in ${ARCHIVE_EXTENSIONS}
+do
+    tar -cjf "${TMP_WORKING_DIR}/${PACKAGES_PATH}/${archive}" ${README_FILE}
+done
+
+echo "Creating dump."
+tar --exclude=${BACKUP_DIRECTORY} --exclude=${README_FILE} -cjf ${ARCHIVE_PATH} -C ${TMP_WORKING_DIR} .
+
+echo "Cleaning."
+rm -R ${README_FILE}
+rm -R ${TMP_WORKING_DIR}
+echo "Done."


### PR DESCRIPTION
JIRA issue: [https://jira.ez.no/browse/COM-20017](https://jira.ez.no/browse/COM-20017)

# Description
The proposed bash script is responsible for creating ezplatform.com storage dump.
As described in [#20017](https://jira.ez.no/browse/COM-20017) all .bz2 and .gz archives were changed to small archives which contain only one text file with information:
> Please download archive from http://ezplatform.com

Moreover, currently created archive does not contain ``image/_aliases`` directory.
In effect, created dump archive size was decreased from ~630MB to ~10MB. 

The script doesn't use production files. Before creating dump archive all required files are copied to the temporary directory. 

## Usage
The script requires two arguments:
1. temporary working dir path, e.g.: ``/tmp/dump``
2. path to eZ Platform installation path, e.g.: ``/var/www/installation_dir``

**Note:** This file should not be added to the repository. I've created PR just only for review.