### PR TITLE
Fix for update bundle command when values are null

### DIFF
--- a/app/Resources/views/themes/ezplatform/line/bundle_card.html.twig
+++ b/app/Resources/views/themes/ezplatform/line/bundle_card.html.twig
@@ -3,7 +3,9 @@
         <div class="bundle-card-line-data">
             <div class="bundle-card-line-information">
                 <h2>
-                    {{ ez_render_field(content, 'bundle_id') }}
+                    <a href="{{ ez_field_value(content, 'packagist_url') }}" title="See on Packagist.org">
+                        {{ ez_render_field(content, 'bundle_id') }}
+                    </a>
                 </h2>
                 <div class="bundle-card-line-description">
                     {{ ez_render_field(content, 'description') }}

--- a/src/AppBundle/Command/UpdateBundlesListCommand.php
+++ b/src/AppBundle/Command/UpdateBundlesListCommand.php
@@ -108,6 +108,13 @@ class UpdateBundlesListCommand extends ContainerAwareCommand
      */
     private function getContentUpdateStruct(ContentService $contentService, $package)
     {
+        if ($package['stars'] == null) {
+            $package['stars'] = 0;
+        }
+        if ($package['forks'] == null) {
+            $package['forks'] = 0;
+        }
+
         $contentUpdateStruct = $contentService->newContentUpdateStruct();
         $contentUpdateStruct->initialLanguageCode = 'eng-GB';
         $contentUpdateStruct->setField('updated', (int)$package['updated']->format('U'));


### PR DESCRIPTION
This "bug" appears when the value on packagist are null (see screenshot below)
![image](https://user-images.githubusercontent.com/1157233/32352689-a7a9513e-bff8-11e7-99e3-5f3f7e8ac1ca.png)

The content item is updated with `null` as value and we want to display 0.