### PR TITLE
COM-20032: Unable to see the list of tag related content

### DIFF
--- a/app/Resources/NetgenTagsBundle/views/tag/view.html.twig
+++ b/app/Resources/NetgenTagsBundle/views/tag/view.html.twig
@@ -1,4 +1,4 @@
-{% set pagelayoutTemplate = "@ezdesign/" ~ ezpublish.configResolver.parameter( 'tag_view.pagelayout', 'eztags' ) %}
+{% set pagelayoutTemplate = "@ezdesign/" ~ ezpublish.configResolver.parameter( 'tag_view.pagelayout', 'netgen_tags' ) %}
 {% extends pagelayoutTemplate %}
 
 {% set tag_keyword = netgen_tags_tag_keyword( tag ) %}

--- a/app/Resources/NetgenTagsBundle/views/tag/view.html.twig
+++ b/app/Resources/NetgenTagsBundle/views/tag/view.html.twig
@@ -1,4 +1,5 @@
-{% extends ezpublish.configResolver.parameter( 'tag_view.pagelayout', 'eztags' ) %}
+{% set pagelayoutTemplate = "@ezdesign/" ~ ezpublish.configResolver.parameter( 'tag_view.pagelayout', 'eztags' ) %}
+{% extends pagelayoutTemplate %}
 
 {% set tag_keyword = netgen_tags_tag_keyword( tag ) %}
 

--- a/app/config/config_ezplatform_page.yml
+++ b/app/config/config_ezplatform_page.yml
@@ -26,7 +26,7 @@ parameters:
     # names of excluded bundle maintainers
     bundles.excluded_maintainers: ['ezrobot']
     # overwrites default tag view page template
-    eztags.default.tag_view.pagelayout: 'pagelayout.html.twig'
+    netgen_tags.default.tag_view.pagelayout: 'pagelayout.html.twig'
     # overwrites default tag related content limit
     eztags.default.tag_view.related_content_list.limit: 10
     # community metrics location ID


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/COM-20032

This PR contains a fix for the 500 error and template exception which appears when you try to open the list of tag related content. 